### PR TITLE
Update NuGet package versions in project files

### DIFF
--- a/src/ServiceCollectionHelpers.AssemblyFinder.UnitTests/ServiceCollectionHelpers.AssemblyFinder.UnitTests.csproj
+++ b/src/ServiceCollectionHelpers.AssemblyFinder.UnitTests/ServiceCollectionHelpers.AssemblyFinder.UnitTests.csproj
@@ -24,12 +24,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.6" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.9.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.9.2" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/ServiceCollectionHelpers.AssemblyFinder/ServiceCollectionHelpers.AssemblyFinder.csproj
+++ b/src/ServiceCollectionHelpers.AssemblyFinder/ServiceCollectionHelpers.AssemblyFinder.csproj
@@ -23,8 +23,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.6" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Updated `ServiceCollectionHelpers.AssemblyFinder.UnitTests.csproj` and `ServiceCollectionHelpers.AssemblyFinder.csproj` to use newer versions of several NuGet packages. Versions for `Microsoft.Extensions.Configuration`, `Microsoft.Extensions.Configuration.Json`, `Microsoft.Extensions.DependencyInjection`, `Microsoft.NET.Test.Sdk`, `MSTest.TestAdapter`, and `MSTest.TestFramework` have been incremented from `9.0.4` to `9.0.6`, and the test SDK version has been updated from `17.13.0` to `17.14.1`. Additionally, `Microsoft.Extensions.Configuration.Abstractions` and `Microsoft.Extensions.DependencyInjection.Abstractions` have also been updated to version `9.0.6`.

Resolves #18